### PR TITLE
use '#!/usr/bin/env bash' instead of '#!/bin/bash' in model download script

### DIFF
--- a/scripts/download_chat_model.sh
+++ b/scripts/download_chat_model.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Download chat model for macOS and Linux
 
 set -e


### PR DESCRIPTION
...because not all environments have bash at `/bin/bash`
Using `/usr/bin/env` will let the script resolve the actual path of whatever bash is used by default in the environment