### PR TITLE
Set up Dart logging

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,15 +3,25 @@ import 'package:flutter_starter_example/app.dart';
 import 'package:flutter_starter_example/service_locator.dart';
 import 'package:nobodywho/nobodywho.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:logging/logging.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  setupLogging();
 
   await NobodyWho.init();
 
   setup();
 
   runApp(const MainApp());
+}
+
+void setupLogging() {
+  Logger.root.level = Level.CONFIG;
+  Logger.root.onRecord.listen((record) {
+    print('${record.level.name}: ${record.time}: ${record.message}');
+  });
 }
 
 class MainApp extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -350,7 +350,7 @@ packages:
     source: hosted
     version: "6.1.0"
   logging:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   path_provider: ^2.1.6
   record: ^7.1.1
   shadcn_ui: ^0.56.0
+  logging: 1.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Once https://github.com/nobodywho-ooo/nobodywho/pull/698 is merged, NobodyWho's logs will be sent to Dart's logging package, and then we'll be able to pick them up here. So let's set up a logger to do that by default.

CC https://github.com/nobodywho-ooo/nobodywho/issues/440.